### PR TITLE
♻️ Add token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ A modern SDK for interacting with the BoardGameGeek (BGG) XMLAPI2, written in Ty
 ## Code Example
 
 ```typescript
-import { bgg } from "bgg-sdk";
-// import bgg from "bgg-sdk";
+import { createBggClient } from "bgg-sdk";
+
+// See https://boardgamegeek.com/using_the_xml_api for info on how to obtain an API token
+const bgg = createBggClient({ token: "your-api-token-here" });
 
 const results = await bgg.search({ query: "scythe" });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,58 @@
-import { collection } from "~/routes/collection";
-import { family } from "~/routes/family";
-import { forum } from "~/routes/forum";
-import { forumList } from "~/routes/forumList";
-import { guild } from "~/routes/guild";
-import { hot } from "~/routes/hot";
-import { search } from "~/routes/search";
-import { thing } from "~/routes/thing";
-import { thread } from "~/routes/thread";
-import { user } from "~/routes/user";
-import * as plays from "~/routes/plays";
+import { createAxiosInstance } from "~/lib/axios";
+import { createCollection } from "~/routes/collection";
+import { createFamily } from "~/routes/family";
+import { createForum } from "~/routes/forum";
+import { createForumList } from "~/routes/forumList";
+import { createGuild } from "~/routes/guild";
+import { createHot } from "~/routes/hot";
+import * as playsFactories from "~/routes/plays";
+import { createSearch } from "~/routes/search";
+import { createThing } from "~/routes/thing";
+import { createThread } from "~/routes/thread";
+import { createUser } from "~/routes/user";
 
-/** @namespace */
-export const bgg = {
-  collection,
-  family,
-  forum,
-  forumList,
-  guild,
-  hot,
-  search,
-  thing,
-  thread,
-  user,
-  plays: { ...plays },
+export type BggClient = {
+  collection: ReturnType<typeof createCollection>;
+  family: ReturnType<typeof createFamily>;
+  forum: ReturnType<typeof createForum>;
+  forumList: ReturnType<typeof createForumList>;
+  guild: ReturnType<typeof createGuild>;
+  hot: ReturnType<typeof createHot>;
+  search: ReturnType<typeof createSearch>;
+  thing: ReturnType<typeof createThing>;
+  thread: ReturnType<typeof createThread>;
+  user: ReturnType<typeof createUser>;
+  plays: {
+    id: ReturnType<typeof playsFactories.createId>;
+    username: ReturnType<typeof playsFactories.createUsername>;
+  };
 };
 
-export default bgg;
+export const createBggClient = (config: BggClientConfig): BggClient => {
+  const axios = createAxiosInstance(config);
+
+  return {
+    collection: createCollection(axios),
+    family: createFamily(axios),
+    forum: createForum(axios),
+    forumList: createForumList(axios),
+    guild: createGuild(axios),
+    hot: createHot(axios),
+    search: createSearch(axios),
+    thing: createThing(axios),
+    thread: createThread(axios),
+    user: createUser(axios),
+    plays: {
+      id: playsFactories.createId(axios),
+      username: playsFactories.createUsername(axios),
+    },
+  };
+};
+
+export default createBggClient;
+
+export type BggClientConfig = {
+  token?: string;
+};
 
 export * from "~/routes/types/index";

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,27 +1,37 @@
-import axiosBase from "axios";
+import axiosBase, { type AxiosInstance } from "axios";
 import axiosRetry from "axios-retry";
 import convert from "xml-js";
+import type { BggClientConfig } from "~/index";
 
-export const axios = axiosBase.create({
-  baseURL: "https://boardgamegeek.com/xmlapi2/",
-});
+export const createAxiosInstance = (config: BggClientConfig): AxiosInstance => {
+  const instance = axiosBase.create({
+    baseURL: "https://boardgamegeek.com/xmlapi2/",
+  });
 
-axiosRetry(axios, {
-  retries: 3,
-  retryDelay: axiosRetry.exponentialDelay,
-});
+  axiosRetry(instance, {
+    retries: 3,
+    retryDelay: axiosRetry.exponentialDelay,
+  });
 
-axios.interceptors.response.use(
-  (response) => {
-    try {
-      const jsonData = convert.xml2js(response.data, { compact: true });
-      response.data = jsonData;
-      return response;
-    } catch (error) {
-      throw new Error("Failed to parse XML data from BGG");
-    }
-  },
-  (error) => {
-    return Promise.reject(`Unexpected error calling BGG API: ${error.stack}`);
-  },
-);
+  instance.interceptors.request.use((requestConfig) => {
+    requestConfig.headers.Authorization = `Bearer ${config.token}`;
+    return requestConfig;
+  });
+
+  instance.interceptors.response.use(
+    (response) => {
+      try {
+        const jsonData = convert.xml2js(response.data, { compact: true });
+        response.data = jsonData;
+        return response;
+      } catch {
+        throw new Error("Failed to parse XML data from BGG");
+      }
+    },
+    (error) => {
+      return Promise.reject(`Unexpected error calling BGG API: ${error.stack}`);
+    },
+  );
+
+  return instance;
+};

--- a/src/routes/collection.ts
+++ b/src/routes/collection.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsCollection } from "~/routes/types/params";
@@ -105,12 +105,12 @@ const transformData = (data: ApiResponse): PayloadCollection => {
   };
 };
 
-export const collection = async (
-  params: ParamsCollection,
-): Promise<PayloadCollection> => {
-  const { data } = await axios.get<ApiResponse>("/collection", {
-    params: transformParams(params),
-  });
+export const createCollection = (axios: AxiosInstance) => {
+  return async (params: ParamsCollection): Promise<PayloadCollection> => {
+    const { data } = await axios.get<ApiResponse>("/collection", {
+      params: transformParams(params),
+    });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/family.ts
+++ b/src/routes/family.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsFamily } from "~/routes/types/params";
@@ -87,10 +87,12 @@ const transformData = (data: ApiResponse): PayloadFamily => {
   };
 };
 
-export const family = async (params: ParamsFamily): Promise<PayloadFamily> => {
-  const { data } = await axios.get<ApiResponse>("/family", {
-    params: transformParams(params),
-  });
+export const createFamily = (axios: AxiosInstance) => {
+  return async (params: ParamsFamily): Promise<PayloadFamily> => {
+    const { data } = await axios.get<ApiResponse>("/family", {
+      params: transformParams(params),
+    });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/forum.ts
+++ b/src/routes/forum.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsForum } from "~/routes/types/params";
@@ -52,17 +52,19 @@ const transformData = (data: ApiResponse): PayloadForum => {
   };
 };
 
-export const forum = async (params: ParamsForum): Promise<PayloadForum> => {
-  // If the id provided is not a valid forum, BGG returns 200 with an html error page.
-  // Catch xml parse error and return null.
+export const createForum = (axios: AxiosInstance) => {
+  return async (params: ParamsForum): Promise<PayloadForum> => {
+    // If the id provided is not a valid forum, BGG returns 200 with an html error page.
+    // Catch xml parse error and return null.
 
-  try {
-    const { data } = await axios.get<ApiResponse>("/forum", {
-      params,
-    });
+    try {
+      const { data } = await axios.get<ApiResponse>("/forum", {
+        params,
+      });
 
-    return transformData(data);
-  } catch (error) {
-    return null;
-  }
+      return transformData(data);
+    } catch {
+      return null;
+    }
+  };
 };

--- a/src/routes/forumList.ts
+++ b/src/routes/forumList.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsForumList } from "~/routes/types/params";
@@ -47,12 +47,12 @@ const transformData = (data: ApiResponse): PayloadForumList => {
   };
 };
 
-export const forumList = async (
-  params: ParamsForumList,
-): Promise<PayloadForumList> => {
-  const { data } = await axios.get<ApiResponse>("/forumlist", {
-    params,
-  });
+export const createForumList = (axios: AxiosInstance) => {
+  return async (params: ParamsForumList): Promise<PayloadForumList> => {
+    const { data } = await axios.get<ApiResponse>("/forumlist", {
+      params,
+    });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/guild.ts
+++ b/src/routes/guild.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsGuild } from "~/routes/types/params";
@@ -90,10 +90,12 @@ const transformData = (data: ApiResponse): PayloadGuild => {
   };
 };
 
-export const guild = async (params: ParamsGuild): Promise<PayloadGuild> => {
-  const { data } = await axios.get<ApiResponse>("/guild", {
-    params,
-  });
+export const createGuild = (axios: AxiosInstance) => {
+  return async (params: ParamsGuild): Promise<PayloadGuild> => {
+    const { data } = await axios.get<ApiResponse>("/guild", {
+      params,
+    });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/hot.ts
+++ b/src/routes/hot.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsHot } from "~/routes/types/params";
@@ -49,10 +49,12 @@ const transformData = (data: ApiResponse): PayloadHot => {
   };
 };
 
-export const hot = async (params?: ParamsHot): Promise<PayloadHot> => {
-  const { data } = await axios.get<ApiResponse>("/hot", {
-    params: transformParams(params),
-  });
+export const createHot = (axios: AxiosInstance) => {
+  return async (params?: ParamsHot): Promise<PayloadHot> => {
+    const { data } = await axios.get<ApiResponse>("/hot", {
+      params: transformParams(params),
+    });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/plays/id.ts
+++ b/src/routes/plays/id.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsPlaysId } from "~/routes/types/params";
@@ -98,7 +98,9 @@ const transformData = (data: ApiResponsePlaysId): PayloadPlaysId => {
   };
 };
 
-export const id = async (params: ParamsPlaysId): Promise<PayloadPlaysId> => {
-  const { data } = await axios.get<ApiResponsePlaysId>("/plays", { params });
-  return transformData(data);
+export const createId = (axios: AxiosInstance) => {
+  return async (params: ParamsPlaysId): Promise<PayloadPlaysId> => {
+    const { data } = await axios.get<ApiResponsePlaysId>("/plays", { params });
+    return transformData(data);
+  };
 };

--- a/src/routes/plays/index.ts
+++ b/src/routes/plays/index.ts
@@ -1,2 +1,2 @@
-export { username } from "./username";
-export { id } from "./id";
+export { createId } from "./id";
+export { createUsername } from "./username";

--- a/src/routes/plays/username.ts
+++ b/src/routes/plays/username.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsPlaysUsername } from "~/routes/types/params";
@@ -89,14 +89,13 @@ const transformData = (
   };
 };
 
-export const username = async (
-  params: ParamsPlaysUsername,
-): Promise<PayloadPlaysUsername> => {
-  const { data } = await axios.get<ApiResponsePlaysUsername | ApiResponseError>(
-    "/plays",
-    {
+export const createUsername = (axios: AxiosInstance) => {
+  return async (params: ParamsPlaysUsername): Promise<PayloadPlaysUsername> => {
+    const { data } = await axios.get<
+      ApiResponsePlaysUsername | ApiResponseError
+    >("/plays", {
       params,
-    },
-  );
-  return transformData(data);
+    });
+    return transformData(data);
+  };
 };

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsSearch } from "~/routes/types/params";
@@ -46,9 +46,11 @@ const transformData = (data: ApiResponse): PayloadSearch => {
   };
 };
 
-export const search = async (args: ParamsSearch): Promise<PayloadSearch> => {
-  const params = transformParams(args);
-  const { data } = await axios.get<ApiResponse>(endpoint, { params });
+export const createSearch = (axios: AxiosInstance) => {
+  return async (args: ParamsSearch): Promise<PayloadSearch> => {
+    const params = transformParams(args);
+    const { data } = await axios.get<ApiResponse>(endpoint, { params });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/thing.ts
+++ b/src/routes/thing.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsThing } from "~/routes/types/params";
@@ -600,10 +600,12 @@ const transformData = (data: ApiResponse): PayloadThing => {
   };
 };
 
-export const thing = async (params: ParamsThing): Promise<PayloadThing> => {
-  const { data } = await axios.get<ApiResponse>(endpoint, {
-    params: transformParams(params),
-  });
+export const createThing = (axios: AxiosInstance) => {
+  return async (params: ParamsThing): Promise<PayloadThing> => {
+    const { data } = await axios.get<ApiResponse>(endpoint, {
+      params: transformParams(params),
+    });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/thread.ts
+++ b/src/routes/thread.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsThread } from "~/routes/types/params";
@@ -67,10 +67,12 @@ const transformData = (data: ApiResponse): PayloadThread => {
   };
 };
 
-export const thread = async (params: ParamsThread): Promise<PayloadThread> => {
-  const { data } = await axios.get<ApiResponse>(endpoint, {
-    params,
-  });
+export const createThread = (axios: AxiosInstance) => {
+  return async (params: ParamsThread): Promise<PayloadThread> => {
+    const { data } = await axios.get<ApiResponse>(endpoint, {
+      params,
+    });
 
-  return transformData(data);
+    return transformData(data);
+  };
 };

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,4 +1,4 @@
-import { axios } from "~/lib/axios";
+import type { AxiosInstance } from "axios";
 import { enforceArray } from "~/lib/helpers";
 
 import { ParamsUser } from "~/routes/types/params";
@@ -203,17 +203,19 @@ const transformData = (data: ApiResponse): PayloadUser => {
   };
 };
 
-export const user = async (params: ParamsUser): Promise<PayloadUser | null> => {
-  // If the id provided is not a valid forum, BGG returns 200 with an html error page.
-  // Catch xml parse error and return null.
+export const createUser = (axios: AxiosInstance) => {
+  return async (params: ParamsUser): Promise<PayloadUser | null> => {
+    // If the id provided is not a valid forum, BGG returns 200 with an html error page.
+    // Catch xml parse error and return null.
 
-  try {
-    const { data } = await axios.get<ApiResponse>(endpoint, {
-      params,
-    });
+    try {
+      const { data } = await axios.get<ApiResponse>(endpoint, {
+        params,
+      });
 
-    return transformData(data);
-  } catch (error) {
-    return null;
-  }
+      return transformData(data);
+    } catch {
+      return null;
+    }
+  };
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,14 @@
-import bgg, * as types from "~/index";
+import createBggClient, * as types from "~/index";
 
 describe("BGG Exports", () => {
-  it("should export all routes correctly", () => {
+  it("should export createBggClient factory function", () => {
+    expect(createBggClient).toBeDefined();
+    expect(typeof createBggClient).toBe("function");
+  });
+
+  it("should create a bgg client with all routes", () => {
+    const bgg = createBggClient({ token: "test-token" });
+
     expect(bgg).toBeDefined();
     expect(bgg.collection).toBeDefined();
     expect(bgg.family).toBeDefined();

--- a/tests/lib/axios.test.ts
+++ b/tests/lib/axios.test.ts
@@ -1,11 +1,23 @@
 import MockAdapter from "axios-mock-adapter";
 
-import { axios } from "~/lib/axios";
-
-const mock = new MockAdapter(axios);
+import { createAxiosInstance } from "~/lib/axios";
 
 describe("Axios", () => {
+  it("should add Bearer token to request headers", async () => {
+    const axios = createAxiosInstance({ token: "test-token-123" });
+    const mock = new MockAdapter(axios);
+
+    mock.onGet("/test").reply((config) => {
+      expect(config.headers?.Authorization).toBe("Bearer test-token-123");
+      return [200, '<?xml version="1.0" encoding="utf-8"?><root></root>'];
+    });
+
+    await axios.get("/test");
+  });
+
   it("should reject the promise with an unexpected error message", async () => {
+    const axios = createAxiosInstance({ token: "test-token" });
+    const mock = new MockAdapter(axios);
     const error = new Error("Some unexpected error");
     error.stack = "Error stack trace";
     mock.onGet("/some-url").replyOnce(500);

--- a/tests/routes/collection.test.ts
+++ b/tests/routes/collection.test.ts
@@ -1,15 +1,17 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
 import {
   ParamsTransformed,
-  collection,
+  createCollection,
   transformParams,
 } from "~/routes/collection";
 import { ParamsCollection } from "~/routes/types/params";
 import { PayloadCollection } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const collection = createCollection(axios);
 
 const endpoint = "/collection";
 

--- a/tests/routes/family.test.ts
+++ b/tests/routes/family.test.ts
@@ -1,11 +1,17 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { ParamsTransformed, family, transformParams } from "~/routes/family";
+import {
+  ParamsTransformed,
+  createFamily,
+  transformParams,
+} from "~/routes/family";
 import { ParamsFamily } from "~/routes/types/params";
 import { PayloadFamily } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const family = createFamily(axios);
 
 const endpoint = "/family";
 

--- a/tests/routes/forum.test.ts
+++ b/tests/routes/forum.test.ts
@@ -1,11 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { forum } from "~/routes/forum";
+import { createForum } from "~/routes/forum";
 import { ParamsForum } from "~/routes/types/params";
 import { PayloadForum } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const forum = createForum(axios);
 
 const endpoint = "/forum";
 

--- a/tests/routes/forumList.test.ts
+++ b/tests/routes/forumList.test.ts
@@ -1,11 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { forumList } from "~/routes/forumList";
+import { createForumList } from "~/routes/forumList";
 import { ParamsForumList } from "~/routes/types/params";
 import { PayloadForumList } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const forumList = createForumList(axios);
 
 const endpoint = "/forumlist";
 

--- a/tests/routes/guild.test.ts
+++ b/tests/routes/guild.test.ts
@@ -1,14 +1,16 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { guild } from "~/routes/guild";
+import { createGuild } from "~/routes/guild";
 import { ParamsGuild } from "~/routes/types/params";
 import {
   PayloadGuildSuccess,
   PayloadGuildError,
 } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const guild = createGuild(axios);
 
 const endpoint = "/guild";
 

--- a/tests/routes/hot.test.ts
+++ b/tests/routes/hot.test.ts
@@ -1,11 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { ParamsTransformed, hot, transformParams } from "~/routes/hot";
+import { ParamsTransformed, createHot, transformParams } from "~/routes/hot";
 import { ParamsHot } from "~/routes/types/params";
 import { PayloadHot } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const hot = createHot(axios);
 
 const endpoint = "/hot";
 

--- a/tests/routes/plays/id.test.ts
+++ b/tests/routes/plays/id.test.ts
@@ -1,11 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { id } from "~/routes/plays/id";
+import { createId } from "~/routes/plays/id";
 import { ParamsPlaysId } from "~/routes/types/params";
 import { PayloadPlaysId } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const id = createId(axios);
 
 const endpoint = "/plays";
 

--- a/tests/routes/plays/username.test.ts
+++ b/tests/routes/plays/username.test.ts
@@ -1,11 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { username } from "~/routes/plays/username";
+import { createUsername } from "~/routes/plays/username";
 import { ParamsPlaysUsername } from "~/routes/types/params";
 import { PayloadPlaysUsername } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const username = createUsername(axios);
 
 const endpoint = "/plays";
 

--- a/tests/routes/search.test.ts
+++ b/tests/routes/search.test.ts
@@ -1,16 +1,18 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
 import {
   ParamsTransformed,
   endpoint,
   transformParams,
-  search,
+  createSearch,
 } from "~/routes/search";
 import { ParamsSearch } from "~/routes/types/params";
 import { PayloadSearch } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const search = createSearch(axios);
 
 describe("search", () => {
   it("should make a search query with results and transform them", async () => {

--- a/tests/routes/thing.test.ts
+++ b/tests/routes/thing.test.ts
@@ -1,16 +1,18 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
 import {
   ParamsTransformed,
   endpoint,
-  thing,
+  createThing,
   transformParams,
 } from "~/routes/thing";
 import { ParamsThing } from "~/routes/types/params";
 import { PayloadThing } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const thing = createThing(axios);
 
 describe("thing", () => {
   it("should make a thing query with all params with results and transform them", async () => {

--- a/tests/routes/thread.test.ts
+++ b/tests/routes/thread.test.ts
@@ -1,11 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { endpoint, thread } from "~/routes/thread";
+import { createThread, endpoint } from "~/routes/thread";
 import { ParamsThread } from "~/routes/types/params";
 import { PayloadThread } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const thread = createThread(axios);
 
 describe("thread", () => {
   it("should fetch a thread with results and transform them", async () => {

--- a/tests/routes/user.test.ts
+++ b/tests/routes/user.test.ts
@@ -1,11 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
-import { axios } from "~/lib/axios";
+import { createAxiosInstance } from "~/lib/axios";
 
-import { endpoint, user } from "~/routes/user";
+import { endpoint, createUser } from "~/routes/user";
 import { ParamsUser } from "~/routes/types/params";
 import { PayloadUser } from "~/routes/types/payloads";
 
+const axios = createAxiosInstance({ token: "test-token" });
 const mock = new MockAdapter(axios);
+const user = createUser(axios);
 
 describe("thread", () => {
   it("should fetch a valid user and ransform it", async () => {


### PR DESCRIPTION
This PR allows users to add an API token, per [recent changes to the BGG API that now require authorization](https://boardgamegeek.com/using_the_xml_api).

It does so by implementing an Axios instance factory that takes a config object with a `token`, and attaches the token to every request via Axios interceptor.

This is a breaking change, but without a token, all requests are returning 401 responses from the BGG API, so it is a necessary change.

This change also makes implementing a fix for #2 fairly easy.